### PR TITLE
拖动范围限制->安全范围设置

### DIFF
--- a/src/devTools/core/components/mpDevBubble.vue
+++ b/src/devTools/core/components/mpDevBubble.vue
@@ -55,9 +55,14 @@ tagConfig = reactive(Object.assign(
 ));
 // #endif
 
+let barHeight = sysInfo.statusBarHeight;
 // 获取小程序顶部安全距离
+// #ifdef MP
 let { top, height } = uni.getMenuButtonBoundingClientRect()
-const barHeight = top ? top + height : sysInfo.statusBarHeight;
+if (height) {
+  barHeight = top + height
+}
+// #endif
 // 拖动范围限制
 let dragLimit = {
   min: { x: 0, y: barHeight },

--- a/src/devTools/core/components/mpDevBubble.vue
+++ b/src/devTools/core/components/mpDevBubble.vue
@@ -55,12 +55,15 @@ tagConfig = reactive(Object.assign(
 ));
 // #endif
 
+// 获取小程序顶部安全距离
+let { top, height } = uni.getMenuButtonBoundingClientRect()
+const barHeight = top ? top + height : sysInfo.statusBarHeight;
 // 拖动范围限制
 let dragLimit = {
-  min: { x: 0, y: 0 },
+  min: { x: 0, y: barHeight },
   max: {
     x: sysInfo.screenWidth - 70,
-    y: sysInfo.screenHeight - 24,
+    y: sysInfo.screenHeight - 24 - sysInfo.statusBarHeight,
   },
 };
 

--- a/src/devTools/core/libs/drawView.js
+++ b/src/devTools/core/libs/drawView.js
@@ -26,7 +26,7 @@ function init(options, devTools) {
     min: { x: 0, y: sysInfo.statusBarHeight, },
     max: {
       x: sysInfo.screenWidth - 70,
-      y: sysInfo.screenHeight - 24,
+      y: sysInfo.screenHeight - 24 - sysInfo.statusBarHeight,
     }
   }
 


### PR DESCRIPTION
1、app 的拖动范围底部拖动触控区域时也会有问题，因为试了很多方法也没有办法获得触控区域的高度，故用 sysInfo.statusBarHeight 的高度了，测试了下，正好可以避开触控区域。
2、微信小程序的拖动范围底部也避开了触控区域，顶部除了避开状态栏，还追加了避开小程序右小角退出和收藏区域。
测试：安卓 app，安卓和苹果的微信小程序。其它设备麻烦您测试一下了。